### PR TITLE
fix: leaderboard close button positioning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -154,6 +154,10 @@ body {
   cursor: pointer;
 }
 
+#leaderBoardMenu #can_cel {
+  left: 67%;
+}
+
 #can_cel:hover {
   color: red;
 }


### PR DESCRIPTION
## Changes
1. Specified selector for leaderboard close button
2. Updated positioning

## Purpose
The close button for the leaderboard got shifted and was out of the modal. Moved it into the modal. 

Closes #167 
